### PR TITLE
fix: Modify pull config interval

### DIFF
--- a/watcher/client.go
+++ b/watcher/client.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"github.com/go-co-op/gocron/v2"
 	"github.com/sirupsen/logrus"
+	"time"
 )
 
 type Client interface {
@@ -21,7 +22,7 @@ func NewClient(f func(clientID, clientSecret string) error, clientID, clientSecr
 	}
 
 	_, err = s.NewJob(
-		gocron.CronJob("*/30 * * * * *", true),
+		gocron.DurationJob(time.Second*30),
 		gocron.NewTask(f, clientID, clientSecret),
 	)
 	if err != nil {


### PR DESCRIPTION
Modify the 0,30 seconds per minute dropdown configuration to 30 seconds interval to avoid stressing the server at the same time.
At a later stage, we can consider extracting it as a parameter term, and adding pull intervals and dithering.