### PR TITLE
docs: remove version specification from docker-compose example

### DIFF
--- a/docs/deploy-master.md
+++ b/docs/deploy-master.md
@@ -61,8 +61,6 @@ RPC 端口也可以处理自签名 HTTPS 的 API 连接
 首先创建一个`docker-compose.yaml`文件，写入以下内容
 
 ```yaml
-version: "3"
-
 services:
   frpp-master:
     image: vaalacat/frp-panel:latest

--- a/docs/en/deploy-master.md
+++ b/docs/en/deploy-master.md
@@ -54,8 +54,6 @@ To secure communication, set the environment variables `CLIENT_RPC_URL` and `CLI
 Install Docker and Docker Compose, then create `docker-compose.yaml`:
 
 ```yaml
-version: "3"
-
 services:
   frpp-master:
     image: vaalacat/frp-panel:latest


### PR DESCRIPTION
This PR fixes a warning when using docker-compose.yaml example in the documentation:

```bash
WARN[0000] /root/frp-panel/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

## Environment
Operating system: Ubuntu 24.04.2 LTS
Docker Compose version v2.35.1
