### PR TITLE
fix-bug: https://github.com/VaalaCat/frp-panel/issues/139

### DIFF
--- a/www/components/base/read-write-xterm.tsx
+++ b/www/components/base/read-write-xterm.tsx
@@ -178,7 +178,7 @@ const TerminalComponent = ({ isLoading, clientStatus, reset, setStatus }: Termin
     }
   }, [terminal, isLoading, setStatus])
 
-  return <div ref={ref} style={styles.terminal()} />
+  return <div ref={ref as React.RefObject<HTMLDivElement>} style={styles.terminal()} />
 }
 
 const styles = {

--- a/www/components/base/readonly-xterm.tsx
+++ b/www/components/base/readonly-xterm.tsx
@@ -71,7 +71,7 @@ const LogTerminalComponent = ({ logs, reset }: { logs: string, reset: number }) 
     }
   }, [ref, instance, currentLine])
 
-  return <div ref={ref} style={{ height: '100%', width: '100%' }} />
+  return <div ref={ref as React.RefObject<HTMLDivElement>} style={{ height: '100%', width: '100%'}} />
 }
 
 export default LogTerminalComponent


### PR DESCRIPTION
Fix bug: 
`Type error: Type 'RefObject<HTMLDivElement | null>' 
is not assignable to type 'LegacyRef<HTMLDivElement> | undefined'.`
in: https://github.com/VaalaCat/frp-panel/issues/139
.
TypeScript changed how it handles Refs from 2023–2024.
In the new TS versions:
` RefObject<HTMLDivElement | null> is no longer compatible with
RefObject<HTMLDivElement> `

But in older TS versions → it was allowed (it automatically “widened” the type).