### PR TITLE
support real client IP behind gRPC reverse proxies

### DIFF
--- a/docs/deploy-master.md
+++ b/docs/deploy-master.md
@@ -73,7 +73,7 @@ services:
       MASTER_API_PORT: 9000 # API/WebUI监听端口
       # CLIENT_RPC_URL和CLIENT_API_URL请根据实际情况设置，设置为外部可以通过url访问到master的形式
       # Client 连接 master RPC 的 URL，如果使用反向代理，请设置为通过反向代理访问的 URL（如wss://example.com:443）
-      CLIENT_RPC_URL: grpc://1.2.3.4:9001）
+      CLIENT_RPC_URL: grpc://1.2.3.4:9001
       # Client 连接 master API/WebUI 的 URL，如果使用反向代理，请设置为通过反向代理访问的 URL（如https://example.com:443）
       CLIENT_API_URL: http://1.2.3.4:9000
     volumes:


### PR DESCRIPTION
This change improves client address detection for gRPC connections when frp-panel is deployed behind a reverse proxy.

Currently, `ClientAddr()` relies only on `peer.FromContext()`, which returns the direct gRPC peer address. When a reverse proxy such as Nginx, EdgeOne, or another CDN/proxy is used, the displayed client address becomes the proxy's address instead of the original client IP.

This change updates `ClientAddr()` to:

* Prefer `X-Real-IP` from incoming gRPC metadata.
* Fall back to the first valid IP in `X-Forwarded-For`.
* Preserve the existing `peer.Addr` behavior when proxy headers are unavailable.

This keeps direct gRPC deployments fully compatible while allowing deployments behind trusted reverse proxies to display the actual client IP.

Example proxy configuration:

```nginx
grpc_set_header X-Real-IP $remote_addr;
grpc_set_header X-Forwarded-For $remote_addr;
```

Security note:

`X-Real-IP` and `X-Forwarded-For` should only be trusted when requests come through a trusted reverse proxy. Deployments should restrict direct access to the gRPC origin or configure the proxy trust boundary appropriately.
